### PR TITLE
Version 2.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,16 @@ Install via NuGet:
 
 ```
 // Package Manager
-Install-Package Crowdin.Api -Version 2.5.0
+Install-Package Crowdin.Api -Version 2.5.1
 
 // .Net CLI
-dotnet add package Crowdin.Api --version 2.5.0
+dotnet add package Crowdin.Api --version 2.5.1
 
 // Package Reference
-<PackageReference Include="Crowdin.Api" Version="2.5.0" />
+<PackageReference Include="Crowdin.Api" Version="2.5.1" />
 
 // Paket CLI
-paket add Crowdin.Api --version 2.5.0
+paket add Crowdin.Api --version 2.5.1
 ```
 
 

--- a/src/Crowdin.Api/Crowdin.Api.nuspec
+++ b/src/Crowdin.Api/Crowdin.Api.nuspec
@@ -2,7 +2,7 @@
 <package  xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>Crowdin.Api</id>
-    <version>2.5.0</version>
+    <version>2.5.1</version>
     <title>Crowdin API client</title>
     <authors>Crowdin</authors>
     <owners>Crowdin</owners>


### PR DESCRIPTION
### Fixed

- languageId should be a string, not an int (#54)
- TranslationProjectBuild.Attributes type array -> object (#56)
- API Updates: remove "useGlobalTm" field for Enterprise API models (#57)