### PR TITLE
Version 2.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,16 @@ Install via NuGet:
 
 ```
 // Package Manager
-Install-Package Crowdin.Api -Version 2.5.1
+Install-Package Crowdin.Api -Version 2.5.2
 
 // .Net CLI
-dotnet add package Crowdin.Api --version 2.5.1
+dotnet add package Crowdin.Api --version 2.5.2
 
 // Package Reference
-<PackageReference Include="Crowdin.Api" Version="2.5.1" />
+<PackageReference Include="Crowdin.Api" Version="2.5.2" />
 
 // Paket CLI
-paket add Crowdin.Api --version 2.5.1
+paket add Crowdin.Api --version 2.5.2
 ```
 
 

--- a/src/Crowdin.Api/Crowdin.Api.nuspec
+++ b/src/Crowdin.Api/Crowdin.Api.nuspec
@@ -2,7 +2,7 @@
 <package  xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>Crowdin.Api</id>
-    <version>2.5.1</version>
+    <version>2.5.2</version>
     <title>Crowdin API client</title>
     <authors>Crowdin</authors>
     <owners>Crowdin</owners>

--- a/src/Crowdin.Api/Translations/ProjectBuild.cs
+++ b/src/Crowdin.Api/Translations/ProjectBuild.cs
@@ -48,8 +48,8 @@ namespace Crowdin.Api.Translations
             [JsonProperty("directoryId")]
             public int? DirectoryId { get; set; }
             
-            [JsonProperty("targetLanguagesId")]
-            public string[] TargetLanguagesId { get; set; }
+            [JsonProperty("targetLanguageIds")]
+            public string[] TargetLanguageIds { get; set; }
             
             [JsonProperty("skipUntranslatedStrings")]
             public bool SkipUntranslatedStrings { get; set; }

--- a/src/Crowdin.Api/Translations/TranslationProjectBuild.cs
+++ b/src/Crowdin.Api/Translations/TranslationProjectBuild.cs
@@ -41,8 +41,8 @@ namespace Crowdin.Api.Translations
             [JsonProperty("directoryId")]
             public int? DirectoryId { get; set; }
             
-            [JsonProperty("targetLanguagesId")]
-            public string[] TargetLanguagesId { get; set; }
+            [JsonProperty("targetLanguageIds")]
+            public string[] TargetLanguageIds { get; set; }
         
             [JsonProperty("skipUntranslatedStrings")]
             public bool SkipUntranslatedStrings { get; set; }

--- a/tests/Crowdin.Api.Tests/Translations/TranslationsApiTests.cs
+++ b/tests/Crowdin.Api.Tests/Translations/TranslationsApiTests.cs
@@ -108,6 +108,9 @@ namespace Crowdin.Api.Tests.Translations
             Assert.Equal(projectId, response.Data[0].ProjectId);
             Assert.Null(response.Data[0].Attributes.BranchId);
             Assert.Null(response.Data[0].Attributes.DirectoryId);
+            
+            Assert.NotNull(response.Data[0].Attributes.TargetLanguageIds);
+            Assert.Empty(response.Data[0].Attributes.TargetLanguageIds);
         }
     }
 }


### PR DESCRIPTION
### Fixed

* field name `targetLanguagesId` should be `targetLanguageIds` ([Fix: field name "TargetLanguageIds"](https://github.com/crowdin/crowdin-api-client-dotnet/pull/59))