### PR TITLE
fix: StringBatchOperations: add support for missing Pagination object

### DIFF
--- a/src/Crowdin.Api/Core/JsonParser.cs
+++ b/src/Crowdin.Api/Core/JsonParser.cs
@@ -61,7 +61,10 @@ namespace Crowdin.Api.Core
                     .Select(ParseResponseObject<TData>)
                     .ToList(),
                 
-                Pagination = ParseResponseObject<Pagination>(rootElement["pagination"]!)
+                Pagination =
+                    rootElement["pagination"] != null
+                    ? ParseResponseObject<Pagination>(rootElement["pagination"]!)
+                    : null
             };
         }
         

--- a/src/Crowdin.Api/ResponseList.cs
+++ b/src/Crowdin.Api/ResponseList.cs
@@ -2,13 +2,15 @@
 using System.Collections.Generic;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Crowdin.Api
 {
     [PublicAPI]
     public class ResponseList<TData>
     {
-        public List<TData> Data { get; set; }
+        public List<TData> Data { get; set; } = new List<TData>();
         
-        public Pagination Pagination { get; set; }
+        public Pagination? Pagination { get; set; }
     }
 }

--- a/tests/Crowdin.Api.Tests/Core/Resources/SourceStrings.Designer.cs
+++ b/tests/Crowdin.Api.Tests/Core/Resources/SourceStrings.Designer.cs
@@ -154,5 +154,29 @@ namespace Crowdin.Api.Tests.Core.Resources {
                 return ResourceManager.GetString("StringBatchOperations_Response", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {
+        ///    &quot;data&quot;: [
+        ///        {
+        ///            &quot;data&quot;: {
+        ///                &quot;id&quot;: 468549,
+        ///                &quot;projectId&quot;: 11,
+        ///                &quot;fileId&quot;: 1533,
+        ///                &quot;branchId&quot;: null,
+        ///                &quot;directoryId&quot;: 1535,
+        ///                &quot;identifier&quot;: &quot;bulk_edit_6&quot;,
+        ///                &quot;text&quot;: &quot;Batch operations with send patch request&quot;,
+        ///                &quot;type&quot;: &quot;text&quot;,
+        ///                &quot;context&quot;: &quot;edited context using patch request&quot;,
+        ///                &quot;maxLength&quot;: 0,
+        ///                &quot;isHidden&quot;: false,
+        ///       [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string StringBatchOperations_Response_NoPagination {
+            get {
+                return ResourceManager.GetString("StringBatchOperations_Response_NoPagination", resourceCulture);
+            }
+        }
     }
 }

--- a/tests/Crowdin.Api.Tests/Core/Resources/SourceStrings.resx
+++ b/tests/Crowdin.Api.Tests/Core/Resources/SourceStrings.resx
@@ -122,4 +122,33 @@
   }
 }</value>
     </data>
+    <data name="StringBatchOperations_Response_NoPagination" xml:space="preserve">
+        <value>{
+    "data": [
+        {
+            "data": {
+                "id": 468549,
+                "projectId": 11,
+                "fileId": 1533,
+                "branchId": null,
+                "directoryId": 1535,
+                "identifier": "bulk_edit_6",
+                "text": "Batch operations with send patch request",
+                "type": "text",
+                "context": "edited context using patch request",
+                "maxLength": 0,
+                "isHidden": false,
+                "isDuplicate": false,
+                "masterStringId": null,
+                "revision": 58,
+                "hasPlurals": false,
+                "isIcu": false,
+                "labelIds": [],
+                "createdAt": "2023-06-05T12:00:32+02:00",
+                "updatedAt": "2023-06-05T18:38:26+02:00"
+            }
+        }
+    ]
+}</value>
+    </data>
 </root>

--- a/tests/Crowdin.Api.Tests/ProjectsGroups/ProjectsApiTests.cs
+++ b/tests/Crowdin.Api.Tests/ProjectsGroups/ProjectsApiTests.cs
@@ -49,7 +49,7 @@ namespace Crowdin.Api.Tests.ProjectsGroups
                 await executor.ListProjects<EnterpriseProject>(userId, groupId, hasManagerAccess);
             
             Assert.NotNull(projectsList);
-            Assert.Equal(25, projectsList.Pagination.Limit);
+            Assert.Equal(25, projectsList.Pagination?.Limit);
             Assert.Single(projectsList.Data);
             Assert.NotNull(projectsList.Data[0].TargetLanguages);
             Assert.Single(projectsList.Data[0].TargetLanguages);

--- a/tests/Crowdin.Api.Tests/SourceStrings/StringBatchOperationsTests.cs
+++ b/tests/Crowdin.Api.Tests/SourceStrings/StringBatchOperationsTests.cs
@@ -98,6 +98,31 @@ namespace Crowdin.Api.Tests.SourceStrings
             Assert_SourceString(response.Data?.Single());
         }
 
+        [Fact]
+        public async Task StringBatchOperations_NoPagination()
+        {
+            const int projectId = 1;
+
+            StringBatchOpPatch[] patches = Array.Empty<StringBatchOpPatch>();
+            
+            Mock<ICrowdinApiClient> mockClient = TestUtils.CreateMockClientWithDefaultParser();
+
+            var url = $"/projects/{projectId}/strings";
+
+            mockClient
+                .Setup(client => client.SendPatchRequest(url, patches, null))
+                .ReturnsAsync(new CrowdinApiResult
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    JsonObject = JObject.Parse(Core.Resources.SourceStrings.StringBatchOperations_Response_NoPagination)
+                });
+
+            var executor = new SourceStringsApiExecutor(mockClient.Object);
+            ResponseList<SourceString> response = await executor.StringBatchOperations(projectId, patches);
+            
+            Assert.NotNull(response);
+        }
+
         private static void Assert_SourceString(SourceString? sourceString)
         {
             Assert.NotNull(sourceString);

--- a/tests/Crowdin.Api.Tests/Storage/StorageApiTests.cs
+++ b/tests/Crowdin.Api.Tests/Storage/StorageApiTests.cs
@@ -36,7 +36,7 @@ namespace Crowdin.Api.Tests.Storage
             ResponseList<StorageResource> response = await storageApi.ListStorages();
             
             Assert.NotEmpty(response.Data);
-            Assert.Equal(0, response.Pagination.Offset);
+            Assert.Equal(0, response.Pagination?.Offset);
         }
 
         [Fact]


### PR DESCRIPTION
Now `ResponseList<T>.Pagination` property marked as nullable via NRT
Added test case from #150

Closes #150 