### PR TITLE
feat: Handle includePreTranslatedStringsOnly parameter for AddTaskRequest

### DIFF
--- a/src/Crowdin.Api/Tasks/LanguageServiceTaskCreateForm.cs
+++ b/src/Crowdin.Api/Tasks/LanguageServiceTaskCreateForm.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
@@ -9,7 +8,7 @@ using Newtonsoft.Json;
 namespace Crowdin.Api.Tasks
 {
     [PublicAPI]
-    public class TaskCreateForm : AddTaskRequest
+    public class LanguageServiceTaskCreateForm : AddTaskRequest
     {
         [JsonProperty("title")]
 #pragma warning disable CS8618
@@ -29,17 +28,17 @@ namespace Crowdin.Api.Tasks
         [JsonProperty("type")]
         public TaskType Type { get; set; }
         
+        [JsonProperty("vendor")]
+        public string Vendor => "crowdin_language_service";
+        
         [JsonProperty("status")]
         public TaskStatus? Status { get; set; }
         
         [JsonProperty("description")]
         public string? Description { get; set; }
         
-        [JsonProperty("splitFiles")]
-        public bool? SplitFiles { get; set; }
-        
-        [JsonProperty("skipAssignedStrings")]
-        public bool? SkipAssignedStrings { get; set; }
+        [JsonProperty("labelIds")]
+        public ICollection<int>? LabelIds { get; set; }
         
         [JsonProperty("skipUntranslatedStrings")]
         public bool? SkipUntranslatedStrings { get; set; }
@@ -47,15 +46,9 @@ namespace Crowdin.Api.Tasks
         [JsonProperty("includePreTranslatedStringsOnly")]
         public bool? IncludePreTranslatedStringsOnly { get; set; }
         
-        [JsonProperty("labelIds")]
-        public ICollection<int>? LabelIds { get; set; }
-        
-        [JsonProperty("assignees")]
-        public ICollection<TaskAssigneeForm>? Assignees { get; set; }
-        
-        [JsonProperty("deadline")]
-        public DateTimeOffset? DeadLine { get; set; }
-        
+        [JsonProperty("includeUntranslatedStringsOnly")]
+        public bool? IncludeUntranslatedStringsOnly { get; set; }
+
         [JsonProperty("dateFrom")]
         public DateTimeOffset? DateFrom { get; set; }
         

--- a/src/Crowdin.Api/Tasks/VendorManualTaskCreateForm.cs
+++ b/src/Crowdin.Api/Tasks/VendorManualTaskCreateForm.cs
@@ -42,6 +42,9 @@ namespace Crowdin.Api.Tasks
         [JsonProperty("skipUntranslatedStrings")]
         public bool? SkipUntranslatedStrings { get; set; }
         
+        [JsonProperty("includePreTranslatedStringsOnly")]
+        public bool? IncludePreTranslatedStringsOnly { get; set; }
+        
         [JsonProperty("labelIds")]
         public ICollection<int>? LabelIds { get; set; }
         

--- a/src/Crowdin.Api/Tasks/VendorOhtTaskCreateForm.cs
+++ b/src/Crowdin.Api/Tasks/VendorOhtTaskCreateForm.cs
@@ -47,6 +47,9 @@ namespace Crowdin.Api.Tasks
         
         [JsonProperty("skipUntranslatedStrings")]
         public bool? SkipUntranslatedStrings { get; set; }
+
+        [JsonProperty("includePreTranslatedStringsOnly")]
+        public bool? IncludePreTranslatedStringsOnly { get; set; }
         
         [JsonProperty("includeUntranslatedStringsOnly")]
         public bool? IncludeUntranslatedStringsOnly { get; set; }


### PR DESCRIPTION
Related issue: https://github.com/crowdin/crowdin-api-client-dotnet/issues/163

Description: 
Crowdin-API's [Add Task](https://developer.crowdin.com/api/v2/#operation/api.projects.tasks.post) API now requires an `includePreTranslatedStringsOnly` parameter. [crowdin-api-client-dotnet](https://github.com/crowdin/crowdin-api-client-dotnet/tree/main) should thus be able to handle requests that contain this parameter within the body.