### PR TITLE
feat: Handle field preTranslateAppliedTo for progress API methods

### DIFF
--- a/src/Crowdin.Api/TranslationStatus/ProgressResourceStatus.cs
+++ b/src/Crowdin.Api/TranslationStatus/ProgressResourceStatus.cs
@@ -12,6 +12,9 @@ namespace Crowdin.Api.TranslationStatus
             
         [JsonProperty("translated")]
         public int Translated { get; set; }
+
+        [JsonProperty("preTranslateAppliedTo")]
+        public int PreTranslateAppliedTo { get; set; }
             
         [JsonProperty("approved")]
         public int Approved { get; set; }


### PR DESCRIPTION
Related Issue: [#162](https://github.com/crowdin/crowdin-api-client-dotnet/issues/162)


Description:
Crowdin's progress API methods now contain the field `preTranslateAppliedTo` in their responses. 
[crowdin-api-client-dotnet](https://github.com/crowdin/crowdin-api-client-dotnet/tree/main) should now be able to handle this.