### PR TITLE
feat: Add includeProjectSourceLanguage prop to Add, Get and Edit Bundles API

### DIFF
--- a/src/Crowdin.Api/Bundles/AddBundleRequest.cs
+++ b/src/Crowdin.Api/Bundles/AddBundleRequest.cs
@@ -36,6 +36,9 @@ namespace Crowdin.Api.Bundles
         [JsonProperty("isMultilingual")]
         public bool? IsMultilingual { get; set; }
         
+        [JsonProperty("includeProjectSourceLanguage")]
+        public bool? IncludeProjectSourceLanguage { get; set; }
+        
         [JsonProperty("labelIds")]
         public ICollection<int>? LabelIds { get; set; }
     }

--- a/src/Crowdin.Api/Bundles/Bundle.cs
+++ b/src/Crowdin.Api/Bundles/Bundle.cs
@@ -29,6 +29,9 @@ namespace Crowdin.Api.Bundles
         [JsonProperty("isMultilingual")]
         public bool IsMultilingual { get; set; }
         
+        [JsonProperty("includeProjectSourceLanguage")]
+        public bool IncludeProjectSourceLanguage  { get; set; }
+        
         [JsonProperty("labelIds")]
         public int[] LabelIds { get; set; }
         

--- a/src/Crowdin.Api/Bundles/BundlePatch.cs
+++ b/src/Crowdin.Api/Bundles/BundlePatch.cs
@@ -33,6 +33,9 @@ namespace Crowdin.Api.Bundles
         [Description("/isMultilingual")]
         IsMultilingual,
         
+        [Description("/includeProjectSourceLanguage")]
+        IncludeProjectSourceLanguage,
+        
         [Description("/labelIds")]
         LabelIds
     }

--- a/tests/Crowdin.Api.Tests/Bundles/BundlesApiTests.cs
+++ b/tests/Crowdin.Api.Tests/Bundles/BundlesApiTests.cs
@@ -65,6 +65,7 @@ namespace Crowdin.Api.Tests.Bundles
                 },
                 ExportPattern = "strings-%two_letter_code%.resx",
                 IsMultilingual = false,
+                IncludeProjectSourceLanguage = false,
                 LabelIds = new[]
                 {
                     0
@@ -146,6 +147,12 @@ namespace Crowdin.Api.Tests.Bundles
                     Operation = PatchOperation.Replace,
                     Path = BundlePatchPath.Name,
                     Value = "Resx bundle"
+                },
+                new BundlePatch
+                {
+                    Operation = PatchOperation.Replace,
+                    Path = BundlePatchPath.IncludeProjectSourceLanguage,
+                    Value = false
                 }
             };
             
@@ -263,6 +270,8 @@ namespace Crowdin.Api.Tests.Bundles
             
             Assert.Equal("strings-%two_letters_code%.resx", model.ExportPattern);
             Assert.False(model.IsMultilingual);
+            
+            Assert.False(model.IncludeProjectSourceLanguage);
             
             Assert.NotNull(model.LabelIds);
             Assert.Single(model.LabelIds);

--- a/tests/Crowdin.Api.Tests/Core/Resources/Bundles.Designer.cs
+++ b/tests/Crowdin.Api.Tests/Core/Resources/Bundles.Designer.cs
@@ -71,6 +71,7 @@ namespace Crowdin.Api.Tests.Core.Resources {
         ///  ],
         ///  &quot;exportPattern&quot;: &quot;strings-%two_letter_code%.resx&quot;,
         ///  &quot;isMultilingual&quot;: false,
+        ///  &quot;includeProjectSourceLanguage&quot;: false,
         ///  &quot;labelIds&quot;: [
         ///    0
         ///  ]
@@ -96,6 +97,7 @@ namespace Crowdin.Api.Tests.Core.Resources {
         ///    ],
         ///    &quot;exportPattern&quot;: &quot;strings-%two_letters_code%.resx&quot;,
         ///    &quot;isMultilingual&quot;: false,
+        ///    &quot;includeProjectSourceLanguage&quot;: false,
         ///    &quot;labelIds&quot;: [
         ///      0
         ///    ],
@@ -152,6 +154,11 @@ namespace Crowdin.Api.Tests.Core.Resources {
         ///    &quot;op&quot;: &quot;replace&quot;,
         ///
         ///    &quot;value&quot;: &quot;Resx bundle&quot;
+        ///  },
+        ///  {
+        ///    &quot;path&quot;: &quot;/includeProjectSourceLanguage&quot;,
+        ///    &quot;op&quot;: &quot;replace&quot;,
+        ///    &quot;value&quot;: false
         ///  }
         ///].
         /// </summary>

--- a/tests/Crowdin.Api.Tests/Core/Resources/Bundles.resx
+++ b/tests/Crowdin.Api.Tests/Core/Resources/Bundles.resx
@@ -60,6 +60,7 @@
   ],
   "exportPattern": "strings-%two_letter_code%.resx",
   "isMultilingual": false,
+  "includeProjectSourceLanguage": false,
   "labelIds": [
     0
   ]
@@ -72,6 +73,11 @@
     "op": "replace",
 
     "value": "Resx bundle"
+  },
+  {
+    "path": "/includeProjectSourceLanguage",
+    "op": "replace",
+    "value": false
   }
 ]</value>
     </data>
@@ -182,6 +188,7 @@
     ],
     "exportPattern": "strings-%two_letters_code%.resx",
     "isMultilingual": false,
+    "includeProjectSourceLanguage": false,
     "labelIds": [
       0
     ],


### PR DESCRIPTION
Fix for issue #178 

### Description

- New Bundles can be created with an `includeProjectSourceLanguage`  property
- A bundle's `includeProjectSourceLanguage`   prop can be edited
- Get response body will include the `includeProjectSourceLanguage` property
- Updated tests to verify above changes