### PR TITLE
fix: add readme to nuget pack 

### DIFF
--- a/src/Crowdin.Api/Crowdin.Api.csproj
+++ b/src/Crowdin.Api/Crowdin.Api.csproj
@@ -18,9 +18,13 @@
         <PackageIconUrl>https://support.crowdin.com/assets/logos/crowdin-dark-symbol.png</PackageIconUrl>
         <PackageProjectUrl>https://github.com/crowdin/crowdin-api-client-dotnet</PackageProjectUrl>
         <PackageTags>crowdin; api; client; sdk</PackageTags>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
     <ItemGroup>
       <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Include="../../README.md" Pack="true" PackagePath="/" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixed issue: #208
I thought that would help the issue 
Changes Made:
 - Updated the project file (src/Crowdin.Api/Crowdin.Api.csproj) to reference the README file.
 (https://devblogs.microsoft.com/nuget/add-a-readme-to-your-nuget-package/)



