### PR TITLE
fix(sourcefiles): handle AggregateException when calling DeleteFile

### DIFF
--- a/src/Crowdin.Api/CrowdinApiClient.cs
+++ b/src/Crowdin.Api/CrowdinApiClient.cs
@@ -279,11 +279,10 @@ namespace Crowdin.Api
             return SendRequest(requestFn);
         }
 
-        Task<HttpStatusCode> ICrowdinApiClient.SendDeleteRequest(string subUrl, IDictionary<string, string>? queryParams)
+        async Task<HttpStatusCode> ICrowdinApiClient.SendDeleteRequest(string subUrl, IDictionary<string, string>? queryParams)
         {
-            return ((ICrowdinApiClient) this)
-                .SendDeleteRequest_FullResult(subUrl, queryParams)
-                .ContinueWith(task => task.Result.StatusCode);
+            var result = await ((ICrowdinApiClient) this).SendDeleteRequest_FullResult(subUrl, queryParams);
+            return result.StatusCode;
         }
         
         Task<CrowdinApiResult> ICrowdinApiClient.SendDeleteRequest_FullResult(string subUrl, IDictionary<string, string>? queryParams)


### PR DESCRIPTION
When using the Crowdin .NET SDK and calling `_crowdinClient.SourceFiles.DeleteFile(...)`, exceptions such as 409 (Conflict) are wrapped in an `AggregateException` due to the use of `Task.Result` in the SDK.

This makes it difficult to catch specific exceptions in client code.

This PR improves exception handling by avoiding the use of `Task.Result` and allowing exceptions to propagate in a more natural and expected way.

Reference to the related code:
https://github.com/crowdin/crowdin-api-client-dotnet/blob/main/src/Crowdin.Api/CrowdinApiClient.cs#L282