### PR TITLE
feat: Add support for string comment attachments

### DIFF
--- a/src/Crowdin.Api/StringComments/AddStringCommentRequest.cs
+++ b/src/Crowdin.Api/StringComments/AddStringCommentRequest.cs
@@ -1,4 +1,5 @@
 ﻿
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 
@@ -21,5 +22,8 @@ namespace Crowdin.Api.StringComments
         
         [JsonProperty("issueType")]
         public IssueType? IssueType { get; set; }
+        
+        [JsonProperty("attachments")]  
+        public List<CommentAttachmentRequest> Attachments { get; set; }  
     }
 }

--- a/src/Crowdin.Api/StringComments/CommentAttachment.cs
+++ b/src/Crowdin.Api/StringComments/CommentAttachment.cs
@@ -1,0 +1,33 @@
+using JetBrains.Annotations;
+using Newtonsoft.Json;
+
+namespace Crowdin.Api.StringComments
+{
+    [PublicAPI]
+    public class CommentAttachment
+    {
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("mime")]
+        public string Mime { get; set; }
+
+        [JsonProperty("size")]
+        public int Size { get; set; }
+
+        [JsonProperty("category")]
+        public string Category { get; set; }
+
+        [JsonProperty("thumbnailUrl")]
+        public string ThumbnailUrl { get; set; }
+
+        [JsonProperty("url")]
+        public string Url { get; set; }
+
+        [JsonProperty("downloadUrl")]
+        public string DownloadUrl { get; set; }
+    }
+}

--- a/src/Crowdin.Api/StringComments/CommentAttachmentRequest.cs
+++ b/src/Crowdin.Api/StringComments/CommentAttachmentRequest.cs
@@ -1,0 +1,12 @@
+using JetBrains.Annotations;
+using Newtonsoft.Json;
+
+namespace Crowdin.Api.StringComments
+{
+    [PublicAPI]
+    public class CommentAttachmentRequest
+    {
+        [JsonProperty("id")]
+        public long Id { get; set; }
+    }
+}

--- a/src/Crowdin.Api/StringComments/IStringCommentsApiExecutor.cs
+++ b/src/Crowdin.Api/StringComments/IStringCommentsApiExecutor.cs
@@ -39,5 +39,7 @@ namespace Crowdin.Api.StringComments
             long projectId,
             long stringCommentId,
             IEnumerable<StringCommentPatch> patches);
+
+        Task DeleteCommentAttachment(long projectId, long stringCommentId, long attachmentId);
     }
 }

--- a/src/Crowdin.Api/StringComments/StringComment.cs
+++ b/src/Crowdin.Api/StringComments/StringComment.cs
@@ -1,5 +1,6 @@
 ﻿
 using System;
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 
@@ -90,5 +91,8 @@ namespace Crowdin.Api.StringComments
             [JsonProperty("fileId")]
             public long FileId { get; set; }
         }
+        
+        [JsonProperty("attachments")]  
+        public List<CommentAttachment> Attachments { get; set; }  
     }
 }

--- a/src/Crowdin.Api/StringComments/StringCommentsApiExecutor.cs
+++ b/src/Crowdin.Api/StringComments/StringCommentsApiExecutor.cs
@@ -132,6 +132,19 @@ namespace Crowdin.Api.StringComments
             CrowdinApiResult result = await _apiClient.SendPatchRequest(url, patches);
             return _jsonParser.ParseResponseObject<StringComment>(result.JsonObject);
         }
+        
+        /// <summary>
+        /// Delete comment attachment. Documentation:
+        /// <a href="https://support.crowdin.com/developer/api/v2/#tag/StringAsset-Comments/operation/api.projects.comments.attachments.delete">Crowdin API</a>
+        /// <a href="https://support.crowdin.com/developer/enterprise/api/v2/#tag/StringAsset-Comments/operation/api.projects.comments.attachments.delete">Crowdin Enterprise API</a>
+        /// </summary>
+        [PublicAPI]
+        public async Task DeleteCommentAttachment(long projectId, long stringCommentId, long attachmentId)  
+        {  
+            string url = FormUrl_CommentAttachment(projectId, stringCommentId, attachmentId);  
+            HttpStatusCode statusCode = await _apiClient.SendDeleteRequest(url);  
+            Utils.ThrowIfStatusNot204(statusCode, $"Comment Attachment {attachmentId} removal failed");  
+        }
 
         #region Helper methods
 
@@ -144,6 +157,11 @@ namespace Crowdin.Api.StringComments
         {
             return $"/projects/{projectId}/comments/{stringCommentId}";
         }
+        
+        private static string FormUrl_CommentAttachment(long projectId, long stringCommentId, long attachmentId)  
+        {  
+            return $"/projects/{projectId}/comments/{stringCommentId}/attachments/{attachmentId}";  
+        }  
 
         #endregion
     }

--- a/tests/Crowdin.Api.UnitTesting/Tests/StringComments/StringCommentsApiTests.cs
+++ b/tests/Crowdin.Api.UnitTesting/Tests/StringComments/StringCommentsApiTests.cs
@@ -100,5 +100,27 @@ namespace Crowdin.Api.UnitTesting.Tests.StringComments
             
             Assert.NotNull(response.Data.FirstOrDefault());
         }
+        
+        [Fact]
+        public async Task DeleteCommentAttachment()
+        {
+            const int projectId = 1;
+            const long stringCommentId = 2814;
+            const long attachmentId = 5678;
+
+            Mock<ICrowdinApiClient> mockClient = TestUtils.CreateMockClientWithDefaultParser();
+
+            var url = $"/projects/{projectId}/comments/{stringCommentId}/attachments/{attachmentId}";
+
+            mockClient
+                .Setup(client => client.SendDeleteRequest(url, null))
+                .ReturnsAsync(HttpStatusCode.NoContent);
+
+            var executor = new StringCommentsApiExecutor(mockClient.Object);
+    
+            await executor.DeleteCommentAttachment(projectId, stringCommentId, attachmentId);
+
+            mockClient.Verify(client => client.SendDeleteRequest(url, null), Times.Once);
+        }
     }
 }


### PR DESCRIPTION
- Add CommentAttachment and CommentAttachmentRequest models
- Update AddStringCommentRequest to support attachments parameter
- Update StringComment to include attachments in response
- Implement DeleteCommentAttachment endpoint
- Add unit test for DeleteCommentAttachment method

Closes #353