### PR TITLE
feat: add styleGuideIds to apply pre-translation requests

### DIFF
--- a/src/Crowdin.Api/Translations/ApplyPreTranslationRequest.cs
+++ b/src/Crowdin.Api/Translations/ApplyPreTranslationRequest.cs
@@ -18,6 +18,9 @@ namespace Crowdin.Api.Translations
         
         [JsonProperty("fileIds")]
         public ICollection<long>? FileIds { get; set; }
+
+        [JsonProperty("styleGuideIds")]
+        public ICollection<long>? StyleGuideIds { get; set; }
         
         [JsonProperty("method")]
         public PreTranslationMethod? Method { get; set; }

--- a/tests/Crowdin.Api.UnitTesting/Tests/Translations/TranslationsApiTests.cs
+++ b/tests/Crowdin.Api.UnitTesting/Tests/Translations/TranslationsApiTests.cs
@@ -138,6 +138,7 @@ namespace Crowdin.Api.UnitTesting.Tests.Translations
             {
                 LanguageIds = new HashSet<string> { "uk" },
                 FileIds = new HashSet<long> { 0 },
+                StyleGuideIds = new HashSet<long> { 1, 2 },
                 Method = PreTranslationMethod.Ai,
                 EngineId = 3434,
                 AiPromptId = 123,
@@ -151,6 +152,25 @@ namespace Crowdin.Api.UnitTesting.Tests.Translations
                 LabelIds = new HashSet<long> { 2, 3 },
                 ExcludeLabelIds = new HashSet<long> { 4 }
             };
+
+            string actualRequestJson = JsonConvert.SerializeObject(body, JsonSettings);
+            string expectedRequestJson = TestUtils.CompactJson(@"{
+                ""languageIds"": [""uk""],
+                ""fileIds"": [0],
+                ""styleGuideIds"": [1, 2],
+                ""method"": ""ai"",
+                ""engineId"": 3434,
+                ""aiPromptId"": 123,
+                ""autoApproveOption"": ""exceptAutoSubstituted"",
+                ""duplicateTranslations"": true,
+                ""translateUntranslatedOnly"": false,
+                ""fallbackLanguages"": {
+                    ""uk"": [""ru"", ""en""]
+                },
+                ""labelIds"": [2, 3],
+                ""excludeLabelIds"": [4]
+            }");
+            Assert.Equal(expectedRequestJson, actualRequestJson);
 
             var mockClient = new Mock<ICrowdinApiClient>();
 


### PR DESCRIPTION
Closes #374.

## Summary

- add `StyleGuideIds` to `ApplyPreTranslationRequest`
- serialize the field as optional `styleGuideIds`
- add request JSON coverage in the Apply Pre-Translation unit test

## Verification

- `DOTNET_ROOT=/Users/stephenkall/.dotnet DOTNET_ROLL_FORWARD=Major PATH=/Users/stephenkall/.dotnet:$PATH dotnet test tests/Crowdin.Api.UnitTesting/Crowdin.Api.UnitTesting.csproj --filter FullyQualifiedName~Crowdin.Api.UnitTesting.Tests.Translations.TranslationsApiTests.ApplyPreTranslationRequest --no-restore`
- `DOTNET_ROOT=/Users/stephenkall/.dotnet DOTNET_ROLL_FORWARD=Major PATH=/Users/stephenkall/.dotnet:$PATH dotnet test tests/Crowdin.Api.UnitTesting/Crowdin.Api.UnitTesting.csproj --no-restore`
- `git diff --check`

Note: the local machine has .NET 10 installed but not the .NET 8 runtime targeted by the tests, so the test commands use `DOTNET_ROLL_FORWARD=Major`. The full unit test project passed: 435 tests.
