### PR TITLE
feat: add update option to string editing endpoints

### DIFF
--- a/src/Crowdin.Api/SourceStrings/ISourceStringsApiExecutor.cs
+++ b/src/Crowdin.Api/SourceStrings/ISourceStringsApiExecutor.cs
@@ -32,13 +32,14 @@ namespace Crowdin.Api.SourceStrings
 
         Task<ResponseList<SourceString>> StringBatchOperations(
             long projectId,
-            IEnumerable<StringBatchOpPatch> patches);
+            IEnumerable<StringBatchOpPatch> patches,
+            UpdateOption? updateOption = null);
 
         Task<SourceString> GetString(long projectId, long stringId, bool denormalizePlaceholders = false);
 
         Task DeleteString(long projectId, long stringId);
 
-        Task<SourceString> EditString(long projectId, long stringId, IEnumerable<SourceStringPatch> patches);
+        Task<SourceString> EditString(long projectId, long stringId, IEnumerable<SourceStringPatch> patches, UpdateOption? updateOption = null);
 
         Task<StringUploadResponseModel> UploadStringsStatus(long projectId, string uploadId);
 

--- a/src/Crowdin.Api/SourceStrings/ISourceStringsApiExecutor.cs
+++ b/src/Crowdin.Api/SourceStrings/ISourceStringsApiExecutor.cs
@@ -30,16 +30,17 @@ namespace Crowdin.Api.SourceStrings
 
         Task<SourceString> AddString(long projectId, AddStringRequest request);
 
-        Task<ResponseList<SourceString>> StringBatchOperations(
-            long projectId,
-            IEnumerable<StringBatchOpPatch> patches,
-            UpdateOption? updateOption = null);
+        Task<ResponseList<SourceString>> StringBatchOperations(long projectId, IEnumerable<StringBatchOpPatch> patches);
+
+        Task<ResponseList<SourceString>> StringBatchOperations(long projectId, IEnumerable<StringBatchOpPatch> patches, UpdateOption updateOption);
 
         Task<SourceString> GetString(long projectId, long stringId, bool denormalizePlaceholders = false);
 
         Task DeleteString(long projectId, long stringId);
 
-        Task<SourceString> EditString(long projectId, long stringId, IEnumerable<SourceStringPatch> patches, UpdateOption? updateOption = null);
+        Task<SourceString> EditString(long projectId, long stringId, IEnumerable<SourceStringPatch> patches);
+
+        Task<SourceString> EditString(long projectId, long stringId, IEnumerable<SourceStringPatch> patches, UpdateOption updateOption);
 
         Task<StringUploadResponseModel> UploadStringsStatus(long projectId, string uploadId);
 

--- a/src/Crowdin.Api/SourceStrings/ISourceStringsApiExecutor.cs
+++ b/src/Crowdin.Api/SourceStrings/ISourceStringsApiExecutor.cs
@@ -32,7 +32,10 @@ namespace Crowdin.Api.SourceStrings
 
         Task<ResponseList<SourceString>> StringBatchOperations(long projectId, IEnumerable<StringBatchOpPatch> patches);
 
-        Task<ResponseList<SourceString>> StringBatchOperations(long projectId, IEnumerable<StringBatchOpPatch> patches, UpdateOption updateOption);
+        Task<ResponseList<SourceString>> StringBatchOperations(
+            long projectId,
+            IEnumerable<StringBatchOpPatch> patches,
+            UpdateOption updateOption);
 
         Task<SourceString> GetString(long projectId, long stringId, bool denormalizePlaceholders = false);
 
@@ -40,7 +43,11 @@ namespace Crowdin.Api.SourceStrings
 
         Task<SourceString> EditString(long projectId, long stringId, IEnumerable<SourceStringPatch> patches);
 
-        Task<SourceString> EditString(long projectId, long stringId, IEnumerable<SourceStringPatch> patches, UpdateOption updateOption);
+        Task<SourceString> EditString(
+            long projectId,
+            long stringId,
+            IEnumerable<SourceStringPatch> patches,
+            UpdateOption updateOption);
 
         Task<StringUploadResponseModel> UploadStringsStatus(long projectId, string uploadId);
 

--- a/src/Crowdin.Api/SourceStrings/SourceStringsApiExecutor.cs
+++ b/src/Crowdin.Api/SourceStrings/SourceStringsApiExecutor.cs
@@ -90,10 +90,17 @@ namespace Crowdin.Api.SourceStrings
         [PublicAPI]
         public async Task<ResponseList<SourceString>> StringBatchOperations(
             long projectId,
-            IEnumerable<StringBatchOpPatch> patches)
+            IEnumerable<StringBatchOpPatch> patches,
+            UpdateOption? updateOption = null)
         {
+            IDictionary<string, string>? queryParams = updateOption.HasValue
+                ? new Dictionary<string, string>()
+                : null;
+
+            queryParams?.AddDescriptionEnumValueIfPresent("updateOption", updateOption);
+
             string url = FormUrl_Strings(projectId);
-            CrowdinApiResult result = await _apiClient.SendPatchRequest(url, patches);
+            CrowdinApiResult result = await _apiClient.SendPatchRequest(url, patches, queryParams);
             return _jsonParser.ParseResponseList<SourceString>(result.JsonObject);
         }
 
@@ -133,10 +140,20 @@ namespace Crowdin.Api.SourceStrings
         /// <a href="https://support.crowdin.com/enterprise/api/#operation/api.projects.strings.patch">Crowdin Enterprise API</a>
         /// </summary>
         [PublicAPI]
-        public async Task<SourceString> EditString(long projectId, long stringId, IEnumerable<SourceStringPatch> patches)
+        public async Task<SourceString> EditString(
+            long projectId,
+            long stringId,
+            IEnumerable<SourceStringPatch> patches,
+            UpdateOption? updateOption = null)
         {
+            IDictionary<string, string>? queryParams = updateOption.HasValue
+                ? new Dictionary<string, string>()
+                : null;
+
+            queryParams?.AddDescriptionEnumValueIfPresent("updateOption", updateOption);
+
             string url = FormUrl_StringId(projectId, stringId);
-            CrowdinApiResult result = await _apiClient.SendPatchRequest(url, patches);
+            CrowdinApiResult result = await _apiClient.SendPatchRequest(url, patches, queryParams);
             return _jsonParser.ParseResponseObject<SourceString>(result.JsonObject);
         }
         

--- a/src/Crowdin.Api/SourceStrings/SourceStringsApiExecutor.cs
+++ b/src/Crowdin.Api/SourceStrings/SourceStringsApiExecutor.cs
@@ -88,16 +88,21 @@ namespace Crowdin.Api.SourceStrings
         /// <a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.strings.batchPatch">Crowdin Enterprise API</a>
         /// </summary>
         [PublicAPI]
-        public async Task<ResponseList<SourceString>> StringBatchOperations(
-            long projectId,
-            IEnumerable<StringBatchOpPatch> patches,
-            UpdateOption? updateOption = null)
+        public async Task<ResponseList<SourceString>> StringBatchOperations(long projectId, IEnumerable<StringBatchOpPatch> patches)
         {
-            IDictionary<string, string>? queryParams = updateOption.HasValue
-                ? new Dictionary<string, string>()
-                : null;
+            string url = FormUrl_Strings(projectId);
+            CrowdinApiResult result = await _apiClient.SendPatchRequest(url, patches);
+            return _jsonParser.ParseResponseList<SourceString>(result.JsonObject);
+        }
 
-            queryParams?.AddDescriptionEnumValueIfPresent("updateOption", updateOption);
+        [PublicAPI]
+        public async Task<ResponseList<SourceString>> StringBatchOperations(long projectId, IEnumerable<StringBatchOpPatch> patches, UpdateOption updateOption)
+        {
+            IDictionary<string, string>? queryParams =
+                new Dictionary<string, string>
+                {
+                    ["updateOption"] = updateOption.ToDescriptionString()
+                };
 
             string url = FormUrl_Strings(projectId);
             CrowdinApiResult result = await _apiClient.SendPatchRequest(url, patches, queryParams);
@@ -140,17 +145,21 @@ namespace Crowdin.Api.SourceStrings
         /// <a href="https://support.crowdin.com/enterprise/api/#operation/api.projects.strings.patch">Crowdin Enterprise API</a>
         /// </summary>
         [PublicAPI]
-        public async Task<SourceString> EditString(
-            long projectId,
-            long stringId,
-            IEnumerable<SourceStringPatch> patches,
-            UpdateOption? updateOption = null)
+        public async Task<SourceString> EditString(long projectId, long stringId, IEnumerable<SourceStringPatch> patches)
         {
-            IDictionary<string, string>? queryParams = updateOption.HasValue
-                ? new Dictionary<string, string>()
-                : null;
+            string url = FormUrl_StringId(projectId, stringId);
+            CrowdinApiResult result = await _apiClient.SendPatchRequest(url, patches);
+            return _jsonParser.ParseResponseObject<SourceString>(result.JsonObject);
+        }
 
-            queryParams?.AddDescriptionEnumValueIfPresent("updateOption", updateOption);
+        [PublicAPI]
+        public async Task<SourceString> EditString(long projectId, long stringId, IEnumerable<SourceStringPatch> patches, UpdateOption updateOption)
+        {
+            IDictionary<string, string> queryParams =
+                new Dictionary<string, string>
+                {
+                    ["updateOption"] = updateOption.ToDescriptionString()
+                };
 
             string url = FormUrl_StringId(projectId, stringId);
             CrowdinApiResult result = await _apiClient.SendPatchRequest(url, patches, queryParams);

--- a/src/Crowdin.Api/SourceStrings/SourceStringsApiExecutor.cs
+++ b/src/Crowdin.Api/SourceStrings/SourceStringsApiExecutor.cs
@@ -13,6 +13,7 @@ namespace Crowdin.Api.SourceStrings
 {
     public class SourceStringsApiExecutor : ISourceStringsApiExecutor
     {
+        private const string UpdateOptionKey = "updateOption";
         private readonly ICrowdinApiClient _apiClient;
         private readonly IJsonParser _jsonParser;
 
@@ -109,7 +110,7 @@ namespace Crowdin.Api.SourceStrings
             IDictionary<string, string> queryParams =
                 new Dictionary<string, string>
                 {
-                    ["updateOption"] = updateOption.ToDescriptionString()
+                    [UpdateOptionKey] = updateOption.ToDescriptionString()
                 };
 
             string url = FormUrl_Strings(projectId);
@@ -175,7 +176,7 @@ namespace Crowdin.Api.SourceStrings
             IDictionary<string, string> queryParams =
                 new Dictionary<string, string>
                 {
-                    ["updateOption"] = updateOption.ToDescriptionString()
+                    [UpdateOptionKey] = updateOption.ToDescriptionString()
                 };
 
             string url = FormUrl_StringId(projectId, stringId);

--- a/src/Crowdin.Api/SourceStrings/SourceStringsApiExecutor.cs
+++ b/src/Crowdin.Api/SourceStrings/SourceStringsApiExecutor.cs
@@ -95,10 +95,18 @@ namespace Crowdin.Api.SourceStrings
             return _jsonParser.ParseResponseList<SourceString>(result.JsonObject);
         }
 
+        /// <summary>
+        /// String Batch Operations with an update option. Documentation:
+        /// <a href="https://developer.crowdin.com/api/v2/#operation/api.projects.strings.batchPatch">Crowdin API</a>
+        /// <a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.strings.batchPatch">Crowdin Enterprise API</a>
+        /// </summary>
         [PublicAPI]
-        public async Task<ResponseList<SourceString>> StringBatchOperations(long projectId, IEnumerable<StringBatchOpPatch> patches, UpdateOption updateOption)
+        public async Task<ResponseList<SourceString>> StringBatchOperations(
+            long projectId,
+            IEnumerable<StringBatchOpPatch> patches,
+            UpdateOption updateOption)
         {
-            IDictionary<string, string>? queryParams =
+            IDictionary<string, string> queryParams =
                 new Dictionary<string, string>
                 {
                     ["updateOption"] = updateOption.ToDescriptionString()
@@ -152,8 +160,17 @@ namespace Crowdin.Api.SourceStrings
             return _jsonParser.ParseResponseObject<SourceString>(result.JsonObject);
         }
 
+        /// <summary>
+        /// Edit string with an update option. Documentation:
+        /// <a href="https://developer.crowdin.com/api/v2/#operation/api.projects.strings.patch">Crowdin API</a>
+        /// <a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.strings.patch">Crowdin Enterprise API</a>
+        /// </summary>
         [PublicAPI]
-        public async Task<SourceString> EditString(long projectId, long stringId, IEnumerable<SourceStringPatch> patches, UpdateOption updateOption)
+        public async Task<SourceString> EditString(
+            long projectId,
+            long stringId,
+            IEnumerable<SourceStringPatch> patches,
+            UpdateOption updateOption)
         {
             IDictionary<string, string> queryParams =
                 new Dictionary<string, string>

--- a/src/Crowdin.Api/SourceStrings/SourceStringsApiExecutor.cs
+++ b/src/Crowdin.Api/SourceStrings/SourceStringsApiExecutor.cs
@@ -163,8 +163,8 @@ namespace Crowdin.Api.SourceStrings
 
         /// <summary>
         /// Edit string with an update option. Documentation:
-        /// <a href="https://developer.crowdin.com/api/v2/#operation/api.projects.strings.patch">Crowdin API</a>
-        /// <a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.strings.patch">Crowdin Enterprise API</a>
+        /// <a href="https://support.crowdin.com/api/v2/#operation/api.projects.strings.patch">Crowdin API</a>
+        /// <a href="https://support.crowdin.com/enterprise/api/#operation/api.projects.strings.patch">Crowdin Enterprise API</a>
         /// </summary>
         [PublicAPI]
         public async Task<SourceString> EditString(

--- a/tests/Crowdin.Api.UnitTesting/Tests/SourceStrings/SourceStringsApiTests.cs
+++ b/tests/Crowdin.Api.UnitTesting/Tests/SourceStrings/SourceStringsApiTests.cs
@@ -170,6 +170,73 @@ namespace Crowdin.Api.UnitTesting.Tests.SourceStrings
             Assert_StringUploadResponseModel(response);
         }
 
+        [Fact]
+        public async Task EditString_WithUpdateOption()
+        {
+            const int projectId = 1;
+            const int stringId = 2814;
+
+            var patches = new[]
+            {
+                new SourceStringPatch
+                {
+                    Operation = PatchOperation.Replace,
+                    Path = StringPatchPath.Text,
+                    Value = "Update Text"
+                }
+            };
+
+            Mock<ICrowdinApiClient> mockClient = TestUtils.CreateMockClientWithDefaultParser();
+
+            string url = $"/projects/{projectId}/strings/{stringId}";
+
+            var mockResponseObject = JObject.Parse(@"
+            {
+              ""data"": {
+                ""id"": 2814,
+                ""projectId"": 2,
+                ""fileId"": 48,
+                ""identifier"": ""name"",
+                ""text"": ""Updated text"",
+                ""type"": ""text"",
+                ""isHidden"": false,
+                ""isDuplicate"": false,
+                ""revision"": 2,
+                ""hasPlurals"": false,
+                ""isIcu"": false,
+                ""labelIds"": [],
+                ""createdAt"": ""2019-09-20T12:43:57+00:00"",
+                ""updatedAt"": ""2019-09-20T13:24:01+00:00""
+              }
+            }");
+
+            mockClient.Setup(
+                client => client.SendPatchRequest(
+                    url,
+                    patches,
+                    It.Is<IDictionary<string, string>>(queryParams =>
+                        queryParams.Count == 1 &&
+                        queryParams.ContainsKey("updateOption") &&
+                        queryParams["updateOption"] == "keep_translations")))
+                        .ReturnsAsync(new CrowdinApiResult
+                        {
+                            StatusCode = HttpStatusCode.OK,
+                            JsonObject = mockResponseObject
+                        });
+
+            var executor = new SourceStringsApiExecutor(mockClient.Object);
+
+            SourceString response = await executor.EditString(
+                projectId,
+                stringId,
+                patches,
+                UpdateOption.KeepTranslations);
+
+            Assert.NotNull(response);
+            Assert.Equal(stringId, response.Id);
+            Assert.Equal("Updated text", response.Text);
+        }
+
         private static void Assert_StringUploadResponseModel(StringUploadResponseModel? response)
         {
             Assert.NotNull(response);

--- a/tests/Crowdin.Api.UnitTesting/Tests/SourceStrings/SourceStringsApiTests.cs
+++ b/tests/Crowdin.Api.UnitTesting/Tests/SourceStrings/SourceStringsApiTests.cs
@@ -173,7 +173,7 @@ namespace Crowdin.Api.UnitTesting.Tests.SourceStrings
         [Fact]
         public async Task EditString_WithUpdateOption()
         {
-            const int projectId = 1;
+            const int projectId = 2;
             const int stringId = 2814;
 
             var patches = new[]

--- a/tests/Crowdin.Api.UnitTesting/Tests/SourceStrings/StringBatchOperationsTests.cs
+++ b/tests/Crowdin.Api.UnitTesting/Tests/SourceStrings/StringBatchOperationsTests.cs
@@ -1,5 +1,6 @@
 ﻿
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -120,6 +121,56 @@ namespace Crowdin.Api.UnitTesting.Tests.SourceStrings
             ResponseList<SourceString> response = await executor.StringBatchOperations(projectId, patches);
 
             Assert.NotNull(response);
+        }
+
+        [Fact]
+        public async Task StringBatchOperations_WithUpdateOption()
+        {
+            const int projectId = 1;
+            const int stringId = 2814;
+
+            var patches = new[]
+            {
+                new StringBatchOpPatch
+                {
+                    Operation = PatchOperation.Replace,
+                    Path = new StringBatchOpPatchPath
+                    {
+                        StringId = stringId,
+                        Property = StringBatchOpPatchPathEntry.Text
+                    },
+                    Value = "Updated Text"
+                }
+            };
+
+            Mock<ICrowdinApiClient> mockClient = TestUtils.CreateMockClientWithDefaultParser();
+
+            string url = $"/projects/{projectId}/strings";
+
+            mockClient.Setup(
+                client => client.SendPatchRequest(
+                    url,
+                    patches,
+                    It.Is<IDictionary<string, string>>(queryParams =>
+                        queryParams.Count == 1 &&
+                        queryParams.ContainsKey("updateOption") &&
+                        queryParams["updateOption"] == "keep_translations")))
+                        .ReturnsAsync(new CrowdinApiResult
+                        {
+                            StatusCode = HttpStatusCode.OK,
+                            JsonObject = JObject.Parse(Resources.SourceStrings.CommonResponses_SingleStringInArray)
+                        });
+
+            var executor = new SourceStringsApiExecutor(mockClient.Object);
+            ResponseList<SourceString> response = await executor.StringBatchOperations(
+                projectId,
+                patches,
+                UpdateOption.KeepTranslations);
+
+            Assert.NotNull(response);
+
+            SourceString sourceString = Assert.Single(response.Data);
+            Assert.Equal(stringId, sourceString.Id);
         }
 
         private static void Assert_SourceString(SourceString? sourceString)


### PR DESCRIPTION
Closes #373 

## Summary: 

- Add optional `updateOption` support to `EditString`
- Add optional `updateOption` support to `StringBatchOperations`
- Add unit tests for both endpoints

## Testing

- `dotnet test`
- 437 tests passed